### PR TITLE
accept non-UTF-8 or binary paths (non-breaking change)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,13 @@ pub enum Error {
 }
 
 #[cfg(target_os = "openbsd")]
-pub fn unveil(path: &str, permissions: &str) -> Result<(), Error> {
+pub fn unveil(path: impl AsRef<[u8]>, permissions: &str) -> Result<(), Error> {
     openbsd::unveil(path, permissions).map_err(Error::Os)
 }
 
 #[cfg(not(target_os = "openbsd"))]
 #[allow(unused_variables)]
-pub fn unveil(path: &str, permissions: &str) -> Result<(), Error> {
+pub fn unveil(path: impl AsRef<[u8]>, permissions: &str) -> Result<(), Error> {
     Err(Error::NotSupported)
 }
 
@@ -24,17 +24,39 @@ pub fn unveil(path: &str, permissions: &str) -> Result<(), Error> {
 mod tests {
     use *;
 
+    // all tests for OpenBSD targets should live in one test function,
+    // because the ones that affect process state need to run in a
+    // specific order. with separate test functions, the tests would
+    // run in a random order (by default) or in lexicographic order
+    // of test names (cargo test -- --test-threads=1).
     #[test]
     #[cfg(target_os = "openbsd")]
     fn test_unveil() {
-        assert!(unveil(".", "r").is_ok());
-    }
+        assert_eq!(
+            unveil(".", "r"),
+            Ok(()),
+            "simple unveil should succeed",
+        );
 
-    #[test]
-    #[cfg(target_os = "openbsd")]
-    fn test_unveil_restrict() {
-        assert!(unveil("", "").is_ok());
-        assert!(unveil(".", "r").is_err());
+        // null(4) is a file, and FFh is a valid filename (despite
+        // being invalid UTF-8), so this should only throw ENOTDIR
+        assert_eq!(
+            unveil(b"/dev/null/\xFF", "r").unwrap_err(),
+            Error::Os(libc::ENOTDIR),
+            "unveil binary path under regular file should throw ENOTDIR",
+        );
+
+        assert_eq!(
+            unveil("", ""),
+            Ok(()),
+            "unveil empty strings should lock successfully",
+        );
+
+        assert_eq!(
+            unveil(".", "r").unwrap_err(),
+            Error::Os(libc::EPERM),
+            "simple unveil after locking should throw EPERM",
+        );
     }
 
     #[test]

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -10,7 +10,8 @@ mod ffi {
     }
 }
 
-pub fn unveil(path: &str, permissions: &str) -> Result<(), i32> {
+pub fn unveil(path: impl AsRef<[u8]>, permissions: &str) -> Result<(), i32> {
+    let path = path.as_ref();
     let cpath = CString::new(path).unwrap();
     let cpermissions = CString::new(permissions).unwrap();
 


### PR DESCRIPTION
This patch loosens crate::unveil’s path argument to `impl AsRef<[u8]>`, making it accept both UTF-8 paths (`&str`) and non-UTF-8 or binary paths (`&[u8]`, `&[u8; N]`, and so on, plus types like `Path` and `OsStr` via explicit conversions). I’ve also fixed a bug where tests would fail randomly (when test_unveil_restrict runs first).

Without this patch, consumers need to skip unveiling or [reject non-UTF-8 paths](https://bitbucket.org/delan/xd/src/0.0.4/src/bin/xd/platform.rs#lines-48:59).

I’ve tested this on Linux and OpenBSD 6.8, and I can test it on OpenBSD 6.4 too if needed.

(see also delan/unveil-rs#1, which GitHub insists on putting in my fork because it’s based on this branch)