### PR TITLE
fix non-empty path with empty permissions (breaking change)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,14 +19,14 @@ pub fn unveil(path: impl AsRef<[u8]>, permissions: &str) -> Result<(), Error> {
 
     // iff path is empty, pass (NULL, NULL) to lock unveil(2). POSIX
     // doesn’t allow empty pathnames, and unveil(2) assigns no other
-    // meaning to empty path as of OpenBSD 6.6, so this is safe.
+    // meaning to empty path as of OpenBSD 6.8, so this is safe.
     if path.is_empty() {
         return openbsd::unveil(None, None).map_err(Error::Os);
     }
 
     // empty permissions means “deny all operations on path”, which
     // is useful to override an ancestor’s allowed operations. there
-    // is no meaning for (non-NULL, NULL) as of OpenBSD 6.6.
+    // is no meaning for (non-NULL, NULL) as of OpenBSD 6.8.
     let path = CString::new(path).map_err(Error::Path)?;
     let permissions = CString::new(permissions).map_err(Error::Permissions)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,34 @@ extern crate libc;
 #[cfg(target_os = "openbsd")]
 mod openbsd;
 
+use std::ffi::{CString, NulError};
+
 #[derive(Debug, PartialEq)]
 pub enum Error {
     NotSupported,
+    Path(NulError),
+    Permissions(NulError),
     Os(i32),
 }
 
 #[cfg(target_os = "openbsd")]
 pub fn unveil(path: impl AsRef<[u8]>, permissions: &str) -> Result<(), Error> {
-    openbsd::unveil(path, permissions).map_err(Error::Os)
+    let path = path.as_ref();
+
+    // iff path is empty, pass (NULL, NULL) to lock unveil(2). POSIX
+    // doesn’t allow empty pathnames, and unveil(2) assigns no other
+    // meaning to empty path as of OpenBSD 6.6, so this is safe.
+    if path.is_empty() {
+        return openbsd::unveil(None, None).map_err(Error::Os);
+    }
+
+    // empty permissions means “deny all operations on path”, which
+    // is useful to override an ancestor’s allowed operations. there
+    // is no meaning for (non-NULL, NULL) as of OpenBSD 6.6.
+    let path = CString::new(path).map_err(Error::Path)?;
+    let permissions = CString::new(permissions).map_err(Error::Permissions)?;
+
+    openbsd::unveil(Some(&path), Some(&permissions)).map_err(Error::Os)
 }
 
 #[cfg(not(target_os = "openbsd"))]
@@ -47,6 +66,18 @@ mod tests {
         );
 
         assert_eq!(
+            unveil("/dev/null", ""),
+            Ok(()),
+            "unveil child with empty permissions should succeed",
+        );
+
+        assert_eq!(
+            unveil("/dev", "r"),
+            Ok(()),
+            "unveil parent should succeed",
+        );
+
+        assert_eq!(
             unveil("", ""),
             Ok(()),
             "unveil empty strings should lock successfully",
@@ -56,6 +87,18 @@ mod tests {
             unveil(".", "r").unwrap_err(),
             Error::Os(libc::EPERM),
             "simple unveil after locking should throw EPERM",
+        );
+
+        use std::fs::File;
+
+        assert!(
+            File::open("/dev/zero").is_ok(),
+            "opening /dev/zero should succeed",
+        );
+
+        assert!(
+            File::open("/dev/null").is_err(),
+            "opening /dev/null should fail",
         );
     }
 

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::io;
 use std::ptr;
 
@@ -10,25 +10,21 @@ mod ffi {
     }
 }
 
-pub fn unveil(path: impl AsRef<[u8]>, permissions: &str) -> Result<(), i32> {
-    let path = path.as_ref();
-    let cpath = CString::new(path).unwrap();
-    let cpermissions = CString::new(permissions).unwrap();
-
-    let cpath_ptr = if !path.is_empty() {
-        cpath.as_ptr()
+pub fn unveil(path: Option<&CStr>, permissions: Option<&CStr>) -> Result<(), i32> {
+    let path = if let Some(path) = path {
+        path.as_ptr()
     } else {
         ptr::null()
     };
 
-    let cpermissions_ptr = if !permissions.is_empty() {
-        cpermissions.as_ptr()
+    let permissions = if let Some(permissions) = permissions {
+        permissions.as_ptr()
     } else {
         ptr::null()
     };
 
     unsafe {
-        match ffi::unveil(cpath_ptr, cpermissions_ptr) {
+        match ffi::unveil(path, permissions) {
             0 => Ok(()),
             _ => Err(io::Error::last_os_error().raw_os_error().unwrap()),
         }


### PR DESCRIPTION
This patch changes the syscall crate::unveil makes when given a non-empty path and empty permissions, from `unveil(path, NULL)` (no meaning, throws EFAULT) to `unveil(path, "")` (deny all operations on the given path).

The behaviour when both path and permissions are empty is unchanged (lock unveil), but as a side effect, an empty path and non-empty permissions now locks unveil too, rather than `unveil(NULL, permissions)` (no meaning, throws EINVAL).

I’ve also fixed a bug where passing strings containing NUL to either argument would panic, by returning one of two new crate::Error variants instead. But adding the variants makes this technically a breaking change, because the type isn’t `#[non_exhaustive]` or similar, so the next version would need to be at least 0.3.0.

I’ve tested this on Linux and OpenBSD 6.8, and I can test it on OpenBSD 6.4 too if needed.

(same as delan/unveil-rs#1)